### PR TITLE
Version blobs using snapshots

### DIFF
--- a/check
+++ b/check
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env ruby
 
 require_relative "azure-blobstore-concourse-resource-common"
@@ -17,16 +18,14 @@ requested_path = version_key ? version_key["path"] : nil
 check_source
 
 azure_response = azure_cli("list #{@container}")
-files = azure_response.map {|f| f['name']}
-matched_files = files.select {|f| f.match @regexp}
+matched_files = azure_response.select {|f| f['name'].match @regexp}
+matched_files.reject! { |f| !f.has_key? 'snapshot' }
 
 names_and_versions = matched_files.map do |f|
-  version = f.match(@regexp)[1]
-  { "filename" => f, "version" => version  }
+  { "filename" => f['name'], "version" => f['snapshot']  }
 end
 
-names_and_versions.reject! { |h| h["version"].match(/[^0-9\.]/) }
-names_and_versions.sort! { |a,b| Gem::Version.new(a["version"]) <=> Gem::Version.new(b["version"])  }
+names_and_versions.sort! { |a,b| a["version"] <=> b["version"] }
 
 if requested_path.nil?
   # return latest

--- a/in
+++ b/in
@@ -7,6 +7,7 @@ request = JSON.parse(STDIN.read)
 
 source = request.fetch("source")
 requested_path = request["version"]["path"]
+snapshot = request["version"]["snapshot"]
 @storage_account_name = source["storage_account_name"]
 @storage_access_key = source["storage_access_key"]
 @container = source["container"]
@@ -18,15 +19,14 @@ check_source
 dest_dir = ARGV[0]
 Dir.chdir(dest_dir)
 basename = File.basename(requested_path)
-response = azure_cli("download --quiet --container #{@container} --destination #{basename} --blob #{requested_path}")
+response = azure_cli("download --quiet --container #{@container} --destination #{basename} --blob #{requested_path} --snapshot #{snapshot}")
 metadata = []
 response.each_pair {|k,v| metadata << {"name"=> k.to_s, "value"=>v.to_s }  }
 
-version = requested_path.match(@regexp)[1]
 File.open(File.join(dest_dir, "version"), "w+") do |f|
-  f.write("#{version}")
+  f.write("#{snapshot}")
 end
 
-puts JSON.dump({ "version" => { "path" => requested_path},
+puts JSON.dump({ "version" => { "path" => requested_path, "snapshot" => snapshot },
                  "metadata" => metadata
                 })

--- a/out
+++ b/out
@@ -40,9 +40,11 @@ else
   dst_path = File.basename(src_file)
 end
 
-response = azure_cli("upload --quiet --container #{@container} --blob #{dst_path} --file #{src_file}")
+azure_cli("upload --quiet --container #{@container} --blob #{dst_path} --file #{src_file}")
+response = azure_cli("snapshot --container #{@container} --blob #{dst_path}")
+
 metadata = []
 response.each_pair {|k,v| metadata << {"name"=> k.to_s, "value"=>v.to_s }  }
-puts JSON.dump({ "version" => { "path" => dst_path },
+puts JSON.dump({ "version" => { "path" => dst_path, "snapshot" => response['snapshot'] },
                  "metadata" => metadata
                 })


### PR DESCRIPTION
This set of commits allows blobs to be versioned properly, this is achieved by having azure snapshot the blobs on upload and then using the path and the snapshot timestamp as it's version.